### PR TITLE
Escaping backslash on windows environments

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -69,7 +69,7 @@ function openFromList(list_promise, tmp_dir_prefix) {
 function getGistDetails(doc = (vscode.window.activeTextEditor ? vscode.window.activeTextEditor.document : undefined)) {
   if (!doc) { return undefined }
   let sep = path.sep;
-  let regexp = new RegExp(".*vscode_gist_([^_]*)_[^" + sep + "]*" + sep + "(.*)");
+  let regexp = new RegExp(".*vscode_gist_([^_]*)_[^\\" + sep + "]*\\" + sep + "(.*)");
   let matches = doc.fileName.match(regexp);
   if (matches) {
     return {


### PR DESCRIPTION
I noticed that when using windows the gists did not get automatically pushed to github as an update, I figured it was because of tokens, but the fact was that the regex used to get the SHA and filename from the tempfile was not escaping backslashes correctly on windows, giving me this error:

```
Invalid regular expression: /.*vscode_gist_([^_]*)_[^\]*\(.*)/: Unterminated character class: SyntaxError: Invalid regular expression: /.*vscode_gist_([^_]*)_[^\]*\(.*)/: Unterminated character class
    at RegExp (native)
    at getGistDetails (C:\Users\Lucas\.vscode\extensions\dbankier.vscode-gist-0.5.2\out\commands\index.js:94:18)
    at onSave (C:\Users\Lucas\.vscode\extensions\dbankier.vscode-gist-0.5.2\out\commands\index.js:204:21)
    at e.invoke (c:\Program Files (x86)\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:7:8778)
    at e.fire (c:\Program Files (x86)\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:7:10231)
    at e._acceptModelSaved (c:\Program Files (x86)\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:16:6526)
    at t.e.handle (c:\Program Files (x86)\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:12:28971)
    at s (c:\Program Files (x86)\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:10:12141)
    at f (c:\Program Files (x86)\Microsoft VS Code\resources\app\out\vs\workbench\node\extensionHostProcess.js:10:12818)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

The printed Regex was `.*vscode_gist_([^_]*)_[^\]*\(.*)` when the correct one should be `.*vscode_gist_([^_]*)_[^\\]*\\(.*)` (see here https://regex101.com/r/vW1xX6/1).

Then I added another backslash to escape the current one, it should not conflict with other systems because in the end backslashes escapes everything directly in front of them so maybe this is one solution.
